### PR TITLE
chore: don't exit on error with iptables TCPMSS

### DIFF
--- a/runtime/entry.sh
+++ b/runtime/entry.sh
@@ -80,7 +80,7 @@ iptables -t nat -I PREROUTING -d "${TS_IP}" -j DNAT --to-destination "${SVC_IP}"
 iptables -t nat -A POSTROUTING -j MASQUERADE
 
 PRIMARY_NETWORK_INTERFACE=$(route | grep '^default' | grep -o '[^ ]*$')
-iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -o ${PRIMARY_NETWORK_INTERFACE} -j TCPMSS --set-mss 1240   
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -o ${PRIMARY_NETWORK_INTERFACE} -j TCPMSS --set-mss 1240 || true
 
 echo "Updating secret with Tailscale IP"
 # patch secret with the tailscale ipv4 address


### PR DESCRIPTION
Add error handling to iptables TCPMSS command.

In Ubuntu 24.04 with linux kernel 6.8. this command returns an error, likely due to the removal of iptables in favor of nftables.

Without this iptables rule, the program still works fine.

Error: iptables: No chain/target/match by that name.